### PR TITLE
Add Planned Completer + Change /today to /recent with tasks for last 48 hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You check out the deployed api [here](https://handoverapp.herokuapp.com/api/task
 ## GET Endpoints
 
 - GET `/tasks` : list all tasks
-- GET `/tasks/today` : list all today's tasks
+- GET `/tasks/recent` : list all tasks created in the last 48 hours
 - GET `/tasks/uncompleted` : list all uncompleted tasks
 - GET `/tasks/{id}` : retrieve a task by id
 - GET `/tasks/byDate?earliestDate={yyyy-MM-dd-hh-mm}&latestDate={yyyy-MM-dd-hh-mm}` : list tasks within a certain date range
@@ -57,6 +57,10 @@ Note: all GET calls return the 200 status code if successful
     "name": "Dr. Donald Duck",
     "grade": "B"
   },
+  "plannedCompleter": {
+    "name": "Dr. Davidson",
+    "grade": "A"
+  },
   "completer": null
 }
 ```
@@ -77,6 +81,10 @@ Note: all GET calls return the 200 status code if successful
   "creator": {
     "name": "Dr. Banana",
     "grade": "bananas cannot have a grade"
+  },
+  "plannedCompleter": {
+    "name": "Dr. Davidson",
+    "grade": "A"
   },
   "completer": {
     "name": "Dr Richards",
@@ -111,6 +119,15 @@ Note: all GET calls return the 200 status code if successful
 {
   "name": "Dr. Donald Duck",
   "grade": "B"
+}
+```
+
+- POST `/tasks/{id}/claim` : claim a task (json body is a Doctor object who is the task completer) (successful claim will return 200 status code)
+
+```json
+{
+  "name": "Dr. Davidson",
+  "grade": "A"
 }
 ```
 

--- a/src/main/java/com/example/handoverapp/controller/DateUtils.java
+++ b/src/main/java/com/example/handoverapp/controller/DateUtils.java
@@ -9,10 +9,10 @@ import java.util.Optional;
 
 public class DateUtils {
 
-    public static Date getYesterday() {
+    public static Date getRecent() {
         ZoneId defaultZoneId = ZoneId.systemDefault();
         LocalDate today = LocalDate.now();
-        LocalDate yesterday = today.minusDays(1);
+        LocalDate yesterday = today.minusDays(2);
         return Date.from(yesterday.atStartOfDay(defaultZoneId).toInstant());
     }
 

--- a/src/main/java/com/example/handoverapp/controller/TaskController.java
+++ b/src/main/java/com/example/handoverapp/controller/TaskController.java
@@ -78,13 +78,13 @@ public class TaskController {
         return ResponseEntity.ok().body(responseBody);
     }
 
-    @GetMapping("/tasks/today")
-    ResponseEntity<List<TaskDTO>> today(
+    @GetMapping("/tasks/recent")
+    ResponseEntity<List<TaskDTO>> recent(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "30") int size
     ) {
         Pageable paging = PageRequest.of(page, size);
-        List<TaskDTO> responseBody = taskService.getAllBetweenDates(DateUtils.getYesterday(), new Date(), paging);
+        List<TaskDTO> responseBody = taskService.getAllBetweenDates(DateUtils.getRecent(), new Date(), paging);
         return ResponseEntity.ok().body(responseBody);
     }
 
@@ -110,6 +110,12 @@ public class TaskController {
     ResponseEntity<TaskDTO> completeTask(@PathVariable("id") Long id, @Valid @RequestBody Doctor doctor) {
         TaskDTO completed = taskService.complete(doctor, id).orElseThrow(() -> new TaskNotFoundException("No task found for this id"));
         return ResponseEntity.ok().body(completed);
+    }
+
+    @PostMapping("/tasks/{id}/claim")
+    ResponseEntity<TaskDTO> claimTask(@PathVariable("id") Long id, @Valid @RequestBody Doctor doctor) {
+        TaskDTO claimed = taskService.claim(doctor, id).orElseThrow(() -> new TaskNotFoundException("No task found for this id"));
+        return ResponseEntity.ok().body(claimed);
     }
 
     // PUT endpoints

--- a/src/main/java/com/example/handoverapp/dto/TaskDTO.java
+++ b/src/main/java/com/example/handoverapp/dto/TaskDTO.java
@@ -25,6 +25,7 @@ public class TaskDTO {
 
     private Doctor creator;
     private Doctor completer;
+    private Doctor plannedCompleter;
 
     public TaskDTO() {}
 
@@ -37,6 +38,7 @@ public class TaskDTO {
         this.gradeRequired = t.getGradeRequired();
         this.completer = t.getCompleter();
         this.creator = t.getCreator();
+        this.plannedCompleter = t.getPlannedCompleter();
         this.id = t.getId();
         if (p != null) {
             this.patientMrn = p.getMrn();
@@ -119,5 +121,13 @@ public class TaskDTO {
 
     public long getId() {
         return id;
+    }
+
+    public Doctor getPlannedCompleter() {
+        return plannedCompleter;
+    }
+
+    public void setPlannedCompleter(Doctor plannedCompleter) {
+        this.plannedCompleter = plannedCompleter;
     }
 }

--- a/src/main/java/com/example/handoverapp/entity/Task.java
+++ b/src/main/java/com/example/handoverapp/entity/Task.java
@@ -38,6 +38,13 @@ public class Task {
     })
     private Doctor completer;
 
+    @Embedded
+    @AttributeOverrides(value = {
+            @AttributeOverride(name = "name", column = @Column(name = "plannedCompleterName")),
+            @AttributeOverride(name = "grade", column = @Column(name = "plannedCompleterGrade"))
+    })
+    private Doctor plannedCompleter;
+
     public Task() {}
 
     public boolean isCompleted() {
@@ -102,5 +109,13 @@ public class Task {
 
     public void setDateCompleted(Date dateCompleted) {
         this.dateCompleted = dateCompleted;
+    }
+
+    public Doctor getPlannedCompleter() {
+        return plannedCompleter;
+    }
+
+    public void setPlannedCompleter(Doctor plannedCompleter) {
+        this.plannedCompleter = plannedCompleter;
     }
 }

--- a/src/main/java/com/example/handoverapp/service/TaskService.java
+++ b/src/main/java/com/example/handoverapp/service/TaskService.java
@@ -77,6 +77,16 @@ public class TaskService {
         }
     }
 
+    public Optional<TaskDTO> claim(Doctor d, long id) {
+        Optional<Task> opTask = tr.findById(id);
+        if (opTask.isPresent()) {
+            Task claimed = claimTask(opTask.get(), d);
+            return Optional.of(new TaskDTO(claimed));
+        } else {
+            return Optional.empty();
+        }
+    }
+
     public TaskDTO create(TaskDTO t) {
         return new TaskDTO(updateFromDTO(t, new Task()));
     }
@@ -135,6 +145,11 @@ public class TaskService {
         task.setCompleted(true);
         task.setDateCompleted(new Date());
         task.setCompleter(doctor);
+        return tr.save(task);
+    }
+
+    private Task claimTask(Task task, Doctor doctor) {
+        task.setPlannedCompleter(doctor);
         return tr.save(task);
     }
 

--- a/src/main/java/com/example/handoverapp/service/TaskService.java
+++ b/src/main/java/com/example/handoverapp/service/TaskService.java
@@ -129,6 +129,7 @@ public class TaskService {
         }
         taskToUpdate.setCompleter(taskDTO.getCompleter());
         taskToUpdate.setCreator(taskDTO.getCreator());
+        taskToUpdate.setPlannedCompleter(taskDTO.getPlannedCompleter());
         boolean isCompleted = taskDTO.isCompleted();
         if (isCompleted && !taskToUpdate.isCompleted()){
             taskToUpdate.setCompleted(taskDTO.isCompleted());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,17 +10,17 @@ spring.datasource.initialization-mode=always
 
 ## HEROKU SETTINGS - make sure this is uncommented when pushing to main
 
-spring.datasource.url=${SPRING_DATASOURCE_URL}
-spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-spring.jpa.hibernate.ddl-auto = update
+#spring.datasource.url=${SPRING_DATASOURCE_URL}
+#spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+#spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+#spring.jpa.hibernate.ddl-auto = update
 
 ## UNCOMMENT THIS AND CHANGE TO LOCAL SETTINGS DURING DEVELOPMENT
 
-#spring.datasource.url=jdbc:postgresql://localhost:5432/handoverdb
-#spring.datasource.username=postgres
-#spring.datasource.password=password
-#spring.jpa.hibernate.ddl-auto = create-drop
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=password
+spring.jpa.hibernate.ddl-auto = create-drop
 
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,17 +10,17 @@ spring.datasource.initialization-mode=always
 
 ## HEROKU SETTINGS - make sure this is uncommented when pushing to main
 
-#spring.datasource.url=${SPRING_DATASOURCE_URL}
-#spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
-#spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
-#spring.jpa.hibernate.ddl-auto = update
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
+spring.jpa.hibernate.ddl-auto = update
 
 ## UNCOMMENT THIS AND CHANGE TO LOCAL SETTINGS DURING DEVELOPMENT
 
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
-spring.datasource.username=postgres
-spring.datasource.password=password
-spring.jpa.hibernate.ddl-auto = create-drop
+#spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+#spring.datasource.username=postgres
+#spring.datasource.password=password
+#spring.jpa.hibernate.ddl-auto = create-drop
 
 
 

--- a/src/test/java/com/example/handoverapp/IntegrationTests.java
+++ b/src/test/java/com/example/handoverapp/IntegrationTests.java
@@ -96,6 +96,34 @@ public class IntegrationTests {
 
     }
 
+    @Test
+    public void claimTaskShouldSetPlannedCompleter() throws Exception {
+        // GIVEN
+
+        MvcResult mvcResult = mockMvc.perform(post("/api/tasks")
+                .content("{\"description\":\"Do some things\",\"patientMrn\":\"12345\",\"patientLocation\":\"Ward B bed 2\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        String location = mvcResult.getResponse().getHeader("Location");
+
+        // WHEN
+
+        mockMvc.perform(post(location+"/claim")
+                .content("{\"name\":\"Dr Stephens\",\"grade\":\"A\"}")
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+
+        // THEN
+
+        mockMvc.perform(get(location)).andExpect(status().isOk())
+                .andExpect(jsonPath("$.description").value("Do some things"))
+                .andExpect(jsonPath("$.plannedCompleter.name").value("Dr Stephens"))
+                .andExpect(jsonPath("$.plannedCompleter.grade").value("A"));
+
+    }
+
 
     @Test
     public void shouldRetrieveEntity() throws Exception {

--- a/src/test/java/com/example/handoverapp/IntegrationTests.java
+++ b/src/test/java/com/example/handoverapp/IntegrationTests.java
@@ -175,13 +175,15 @@ public class IntegrationTests {
         String location = mvcResult.getResponse().getHeader("Location");
 
         mockMvc.perform(put(location)
-                .content("{\"description\":\"Do some things\",\"patientMrn\":\"12345\",\"patientLocation\":\"Ward A bed 2\"}")
+                .content("{\"description\":\"Do some things\",\"patientMrn\":\"12345\",\"patientLocation\":\"Ward A bed 2\",\"plannedCompleter\":{\"name\":\"Jennifer\", \"grade\":\"A\"}}}")
                 .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
         mockMvc.perform(get(location))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description").value("Do some things"))
+                .andExpect(jsonPath("$.plannedCompleter.name").value("Jennifer"))
+                .andExpect(jsonPath("$.plannedCompleter.grade").value("A"))
                 .andExpect(jsonPath("$.patientLocation").value("Ward A bed 2"));
     }
 

--- a/src/test/java/com/example/handoverapp/controller/DateUtilsTest.java
+++ b/src/test/java/com/example/handoverapp/controller/DateUtilsTest.java
@@ -13,14 +13,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class DateUtilsTest {
 
-//    @Test
-//    void getYesterday() {
-//        Date now = new Date();
-//        ZonedDateTime today = now.toInstant().atZone(ZoneId.systemDefault());
-//        ZonedDateTime yesterday = DateUtils.getYesterday().toInstant().atZone(ZoneId.systemDefault());
-//        assertEquals(yesterday.getDayOfMonth(),today.getDayOfMonth() - 1);
-//    }
-
     @Test
     void stringFromDate() throws ParseException {
         SimpleDateFormat sdf = new SimpleDateFormat("dd-M-yyyy hh:mm");

--- a/src/test/java/com/example/handoverapp/dto/TaskDTOTest.java
+++ b/src/test/java/com/example/handoverapp/dto/TaskDTOTest.java
@@ -16,12 +16,14 @@ class TaskDTOTest {
         entity.setDescription("Do these things");
         entity.setPatient(new Patient("ABC123","Very ill","Ward 2 Bed 5"));
         entity.setCreator(new Doctor("Dr Stephens","B"));
+        entity.setPlannedCompleter(new Doctor("Dr Davidson","C"));
         TaskDTO dto = new TaskDTO(entity);
         assertEquals(dto.getPatientMrn(), "ABC123");
         assertEquals(dto.getPatientLocation(), "Ward 2 Bed 5");
         assertEquals(dto.getPatientClinicalSummary(), "Very ill");
         assertEquals(dto.getCreator().getName(), "Dr Stephens");
         assertEquals(dto.getCreator().getGrade(), "B");
+        assertEquals(dto.getPlannedCompleter().getGrade(), "C");
         assertEquals(dto.getGradeRequired(), "ABC");
         assertEquals(dto.getDescription(), "Do these things");
     }

--- a/src/test/java/com/example/handoverapp/service/TaskServiceTest.java
+++ b/src/test/java/com/example/handoverapp/service/TaskServiceTest.java
@@ -54,7 +54,7 @@ class TaskServiceTest {
 
     @Test
     void getAllBetweenDates() {
-        List<TaskDTO> all = service.getAllBetweenDates(DateUtils.getYesterday(), new Date(), pageRequest);
+        List<TaskDTO> all = service.getAllBetweenDates(DateUtils.getRecent(), new Date(), pageRequest);
         assertEquals(all.size(), 1);
         assertEquals(all.get(0).getDescription(), "Do some stuff");
         assertEquals(all.get(0).getPatientMrn(), "123");
@@ -184,6 +184,22 @@ class TaskServiceTest {
         assertTrue(completed.get().isCompleted());
         assertNotNull(completed.get().getDateCompleted());
 
+    }
+
+    @Test
+    void claim() {
+        // GIVEN
+        Task t = new Task();
+        t = service.tr.save(t);
+        Doctor d = new Doctor("Dr Stephens", "22");
+        // WHEN
+        Optional<TaskDTO> claimed = service.claim(d, t.getId());
+        // THEN
+        assertTrue(claimed.isPresent());
+        assertEquals(claimed.get().getPlannedCompleter().getName(), "Dr Stephens");
+        assertEquals(claimed.get().getPlannedCompleter().getGrade(), "22");
+        assertFalse(claimed.get().isCompleted());
+        assertNull(claimed.get().getDateCompleted());
     }
 
     @Test


### PR DESCRIPTION
- '/recent' instead of '/tasks'
- '/recent' returns last 48 hours of tasks
- can add task claimer using '/{id}/claim' POST endpoint
- can add task claimer using ordinary '/{id}' PUT endpoint
- tests updated
- readme updated